### PR TITLE
The bug in finding heuristically the sigma is resolved.

### DIFF
--- a/cbpktst.py
+++ b/cbpktst.py
@@ -59,7 +59,7 @@ def compute_mmd2u_and_null_distributions(Ks, m, n, iterations=1000, seed=0, para
     print("Computing MMD2u for each unit.")
     for i, K in enumerate(Ks):
         mmd2u = MMD2u(K, m, n)
-        unit_statistic[i] = mmd2u
+        unit_statistic[i] = (n+m)*mmd2u # For using asymptotic distribution of MMD the statistic is (n+m)*mmd2u
 
     print("Computing MMD2u's null-distribution, for each unit.")
     if not parallel:

--- a/cbpktst.py
+++ b/cbpktst.py
@@ -32,7 +32,7 @@ def precompute_gaussian_kernels(XX, YY, verbose=False):
         # Heuristic: sigma2 is the median value among all pairwise
         # distances between X and Y. Note: should we use just
         # dm[:m,m:] or all dm?
-        sigma2 = np.median(dm[:m,m:]) 
+        sigma2 = np.median(dm[:m,m:])**2 
         sigma2s[i] = sigma2
         if verbose: print("sigma2 = %s" % sigma2)
         K = np.exp(-dm / sigma2)


### PR DESCRIPTION
According to the original paper (seehttp://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.388.3788&rep=rep1&type=pdf  page 748)  the median distance between samples is used as a heuristic for sigma for Gaussian kernel. It seems in original code this value is used as sigma^2 in computing kernel (i.e., standard deviation is used instead of variance in kernel computation). The updated code resolves this bug.
Further a little bug in computing test statistic is resolved. According to the original paper page 737, in using the asymptotic distribution of MMD based on bootstrapping, the test statistic is (n+m) *MMD and not MMD.
